### PR TITLE
fix sometimes degu send coap message with garbage data

### DIFF
--- a/degu_ota.c
+++ b/degu_ota.c
@@ -202,6 +202,7 @@ int update_init(void)
 		LOG_ERR("Cannot malloc for payload");
 		return 1;
 	}
+	memset(payload, 0, MAX_COAP_MSG_LEN);
 
 	update_flag_script_user = false;
 	update_flag_config_user = false;

--- a/degu_utils.c
+++ b/degu_utils.c
@@ -129,11 +129,11 @@ int degu_coap_request(u8_t *path, u8_t method, u8_t *payload, void (*callback)(u
 	while (1) {
 		switch (method) {
 		case COAP_METHOD_POST:
-			payload_len = strlen(payload);
+			payload_len = strlen((char*)payload);
 			code = zcoap_request_post(sock, coap_path, payload, &payload_len, &last_block);
 			break;
 		case COAP_METHOD_PUT:
-			payload_len = strlen(payload);
+			payload_len = strlen((char*)payload);
 			code = zcoap_request_put(sock, coap_path, payload, &payload_len, &last_block);
 			break;
 		case COAP_METHOD_GET:
@@ -207,6 +207,9 @@ void degu_get_asset(void)
 	key = k_malloc(2048);
 	cert = k_malloc(2048);
 
+	memset(key, 0, 2048);
+	memset(cert, 0, 2048);
+
 	/* At first, we must erase A71CH in here*/
 
 	degu_coap_request("x509/key", COAP_METHOD_GET, key, NULL);
@@ -232,6 +235,9 @@ void degu_send_asset(void)
 
 	key = k_malloc(4096);
 	cert = k_malloc(4096);
+
+	memset(key, 0, 4096);
+	memset(cert, 0, 4096);
 
 	strcpy(key, DEGU_TEST_KEY);
 	strcpy(cert, DEGU_TEST_CERT);

--- a/zcoap.c
+++ b/zcoap.c
@@ -77,6 +77,7 @@ static int zcoap_request(int sock, u8_t *path, u8_t method, u8_t *payload, u16_t
 		LOG_ERR("can't malloc\n");
 		return 0;
 	}
+	memset(data, 0, MAX_COAP_MSG_LEN);
 
 	r = coap_packet_init(&request, data, MAX_COAP_MSG_LEN,
 			     1, COAP_TYPE_CON, sizeof(token), token,


### PR DESCRIPTION
fix #22
add zero clear at k_malloc() area to PUT or POST coap messege.