### PR TITLE
fix CoAP message retransmission

### DIFF
--- a/degu_ota.h
+++ b/degu_ota.h
@@ -22,6 +22,9 @@
  * THE SOFTWARE.
  */
 
+#define DEGU_OTA_OK 1
+#define DEGU_OTA_ERR 0
+
 int update_init(void);
 int check_update(void);
 int do_update(void);

--- a/moddegu.c
+++ b/moddegu.c
@@ -33,6 +33,7 @@ STATIC MP_DEFINE_CONST_FUN_OBJ_1(degu_update_shadow_obj, degu_update_shadow);
 
 STATIC mp_obj_t degu_get_shadow(void) {
 	vstr_t vstr;
+	int ret;
 	u8_t *payload = (u8_t *)m_malloc(MAX_COAP_MSG_LEN);
 
 	if (!payload) {
@@ -41,9 +42,9 @@ STATIC mp_obj_t degu_get_shadow(void) {
 	}
 	memset(payload, 0, MAX_COAP_MSG_LEN);
 
-	degu_coap_request("thing", COAP_METHOD_GET, payload, NULL);
+	ret = degu_coap_request("thing", COAP_METHOD_GET, payload, NULL);
 
-	if (payload != NULL) {
+	if (payload != NULL && ret >= COAP_RESPONSE_CODE_OK) {
 		vstr_init_len(&vstr, strlen(payload));
 		strcpy(vstr.buf, payload);
 		m_free(payload);

--- a/src/zephyr_start.c
+++ b/src/zephyr_start.c
@@ -124,7 +124,7 @@ void main(void) {
 		LOG_ERR("Failed to mount user region");
 	}
 
-	if(update_init()){
+	if(update_init() == DEGU_OTA_OK){
 		if (check_update()) {
 			LOG_INF("Trying to update...");
 			if (do_update()) {
@@ -150,4 +150,3 @@ static int cmd_upython(const struct shell *shell, size_t argc, char **argv)
 	return 0;
 }
 SHELL_CMD_REGISTER(upython, NULL, "micropython interpreterx`", cmd_upython);
-

--- a/src/zephyr_start.c
+++ b/src/zephyr_start.c
@@ -127,7 +127,7 @@ void main(void) {
 	if(update_init() == DEGU_OTA_OK){
 		if (check_update() == DEGU_OTA_OK) {
 			LOG_INF("Trying to update...");
-			if (do_update()) {
+			if (do_update() == DEGU_OTA_OK) {
 				sys_reboot(SYS_REBOOT_COLD);
 			}
 		}

--- a/src/zephyr_start.c
+++ b/src/zephyr_start.c
@@ -125,7 +125,7 @@ void main(void) {
 	}
 
 	if(update_init() == DEGU_OTA_OK){
-		if (check_update()) {
+		if (check_update() == DEGU_OTA_OK) {
 			LOG_INF("Trying to update...");
 			if (do_update()) {
 				sys_reboot(SYS_REBOOT_COLD);

--- a/src/zephyr_start.c
+++ b/src/zephyr_start.c
@@ -124,12 +124,12 @@ void main(void) {
 		LOG_ERR("Failed to mount user region");
 	}
 
-	update_init();
-
-	if (check_update()) {
-		LOG_INF("Trying to update...");
-		if (!do_update()) {
-			sys_reboot(SYS_REBOOT_COLD);
+	if(update_init()){
+		if (check_update()) {
+			LOG_INF("Trying to update...");
+			if (do_update()) {
+				sys_reboot(SYS_REBOOT_COLD);
+			}
 		}
 	}
 

--- a/zcoap.c
+++ b/zcoap.c
@@ -41,6 +41,9 @@
 
 #include "zcoap.h"
 
+#define COAP_ACK_TIMEOUT_SEC 2
+#define COAP_MAX_RETRANSMIT 4
+
 LOG_MODULE_REGISTER(zcoap);
 
 static struct coap_block_context blk_ctx;
@@ -141,7 +144,7 @@ static int zcoap_request(int sock, u8_t *path, u8_t method, u8_t *payload, u16_t
 		}
 	}
 
-	tv.tv_sec = COAP_ACK_TIMEOUT;
+	tv.tv_sec = COAP_ACK_TIMEOUT_SEC;
 	tv.tv_usec = 0;
 	while (1) {
 		r = send(sock, request.data, request.offset, 0);

--- a/zcoap.c
+++ b/zcoap.c
@@ -60,8 +60,10 @@ static int zcoap_request(int sock, u8_t *path, u8_t method, u8_t *payload, u16_t
 	const u8_t *payload_buf;
 	int code;
 	struct timeval tv;
+	u8_t retry;
 
 	code = 0;
+	retry = 0;
 
 	if (blk_ctx.total_size == 0) {
 		if (method == COAP_METHOD_GET) {
@@ -139,22 +141,31 @@ static int zcoap_request(int sock, u8_t *path, u8_t method, u8_t *payload, u16_t
 		}
 	}
 
-	r = send(sock, request.data, request.offset, 0);
-	if (r < 0) {
-		LOG_ERR("Unable to send request\n");
-		goto errorend;
-	}
-
-	FD_ZERO(&fds);
-	FD_SET(sock, &fds);
-	tv.tv_sec = 3;
+	tv.tv_sec = COAP_ACK_TIMEOUT;
 	tv.tv_usec = 0;
+	while (1) {
+		r = send(sock, request.data, request.offset, 0);
+		if (r < 0) {
+			LOG_ERR("Unable to send request\n");
+			goto errorend;
+		}
 
-	r = select(sock + 1, &fds, NULL, NULL, &tv);
-	if (!r) {
-		LOG_ERR("Receiving response timeout\n");
-		code = COAP_FAILED_TO_RECEIVE_RESPONSE;
-		goto errorend;
+		FD_ZERO(&fds);
+		FD_SET(sock, &fds);
+		r = select(sock + 1, &fds, NULL, NULL, &tv);
+		if (!r) {
+			LOG_ERR("Receiving response timeout\n");
+			tv.tv_sec *= 2;
+			retry ++;
+		}
+		else{
+			break;
+		}
+
+		if (retry > COAP_MAX_RETRANSMIT) {
+			code = COAP_FAILED_TO_RECEIVE_RESPONSE;
+			goto errorend;
+		}
 	}
 
 	rcvd = recv(sock, data, MAX_COAP_MSG_LEN, MSG_DONTWAIT);

--- a/zcoap.h
+++ b/zcoap.h
@@ -31,8 +31,6 @@
 #define COAP_TYPE_ACK 2 //Acknowledgement
 #define COAP_TYPE_RST 3 //Reset
 #define COAP_FAILED_TO_RECEIVE_RESPONSE -1
-#define COAP_ACK_TIMEOUT 2
-#define COAP_MAX_RETRANSMIT 4
 
 int zcoap_request_post(int sock, u8_t *path, u8_t *payload, u16_t *payload_len, bool *last_block);
 int zcoap_request_put(int sock, u8_t *path, u8_t *payload, u16_t *payload_len, bool *last_block);

--- a/zcoap.h
+++ b/zcoap.h
@@ -31,6 +31,8 @@
 #define COAP_TYPE_ACK 2 //Acknowledgement
 #define COAP_TYPE_RST 3 //Reset
 #define COAP_FAILED_TO_RECEIVE_RESPONSE -1
+#define COAP_ACK_TIMEOUT 2
+#define COAP_MAX_RETRANSMIT 4
 
 int zcoap_request_post(int sock, u8_t *path, u8_t *payload, u16_t *payload_len, bool *last_block);
 int zcoap_request_put(int sock, u8_t *path, u8_t *payload, u16_t *payload_len, bool *last_block);


### PR DESCRIPTION
fix #25.
```
When timeout, CoAP message is retransmitted, the retransmission counter is incremented, and the timeout is doubled.

ACK_TIMEOUT : 2 seconds(initial value)
MAX_RETRANSMIT : 4

If the retransmission counter reaches MAX_RETRANSMIT, Degu runs the next step.
```