### PR TITLE
Added degu-routing feature

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ SRC_C = main.c \
 	degu_utils.c \
 	degu_ota.c \
 	degu_pm.c \
+	degu_routing.c \
 	zcoap.c \
 	help.c \
 	modusocket.c \

--- a/degu_routing.c
+++ b/degu_routing.c
@@ -1,0 +1,75 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Atmark Techno, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <misc/printk.h>
+#include <stdio.h>
+#include <string.h>
+#include "degu_routing.h"
+#include <openthread/udp.h>
+#include <openthread/message.h>
+#include <openthread/instance.h>
+#include "utils/code_utils.h"
+
+#define RECEV_MCAST_PORT 60888
+#define SEND_MCAST_PORT 50888
+static const char UDP_MCAST[] = "ff03::1";
+static const char UDP_MESG[] = "degu::mcast";
+static otUdpSocket sUdpSocket;
+
+void initUDP_route(otInstance *aInstance)
+{
+        otSockAddr  listenSockAddr;
+
+        memset(&sUdpSocket, 0, sizeof(sUdpSocket));
+        memset(&listenSockAddr, 0, sizeof(listenSockAddr));
+
+        listenSockAddr.mPort    = RECEV_MCAST_PORT;
+
+        otUdpOpen(aInstance, &sUdpSocket, UDPmessageHandler, aInstance);
+        otUdpBind(&sUdpSocket, &listenSockAddr);
+}
+
+void sendUDP_route(otInstance *aInstance)
+{
+       otError         error;
+       otMessage *     message = NULL;
+       otMessageInfo   messageInfo;
+       otIp6Address    destAddr;
+       memset(&messageInfo, 0, sizeof(messageInfo));
+
+       otIp6AddressFromString(UDP_MCAST, &destAddr);
+       messageInfo.mPeerAddr    = destAddr;
+       messageInfo.mPeerPort    = SEND_MCAST_PORT;
+        messageInfo.mInterfaceId = OT_NETIF_INTERFACE_ID_THREAD;
+
+       message = otUdpNewMessage(aInstance, NULL);
+       otEXPECT_ACTION(message != NULL, error = OT_ERROR_NO_BUFS);
+       error = otMessageAppend(message, UDP_MESG, sizeof(UDP_MESG));
+       otEXPECT(error == OT_ERROR_NONE);
+       error = otUdpSend(&sUdpSocket, message, &messageInfo);
+ exit:
+       if (error != OT_ERROR_NONE && message != NULL)
+       {
+               otMessageFree(message);
+       }
+}

--- a/degu_routing.h
+++ b/degu_routing.h
@@ -1,0 +1,37 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Atmark Techno, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef __DEGU_ROUTING_H__
+#define __DEGU_ROUTING_H__
+
+#include <stdio.h>
+#include <openthread/instance.h>
+#include <openthread/udp.h>
+
+void sendUDP_route(otInstance *aInstance);
+void UDPmessageHandler(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
+void initUDP_route(otInstance *aInstance);
+
+#endif /* ___DEGU_ROUTING_H__ */
+

--- a/src/zephyr_start.c
+++ b/src/zephyr_start.c
@@ -40,14 +40,18 @@
 #include <stdio.h>
 #include "../version.h"
 
-#ifdef ROUTER_ONLY
+
 #include <net/net_if.h>
 #include <net/openthread.h>
 #include <openthread/thread.h>
 #include <openthread/thread_ftd.h>
+#include <openthread/message.h>
+#include <openthread/udp.h>
+#include <openthread/instance.h>
+
+#ifdef ROUTER_ONLY
 #define OT_LEADER_WEIGHT 1
 #endif
-
 
 LOG_MODULE_REGISTER(main);
 
@@ -133,13 +137,13 @@ no_script:
 
 void main(void) {
 	int err = 0;
-
-#ifdef ROUTER_ONLY
 	struct net_if *iface = net_if_get_default();
 	struct openthread_context *ot_context = net_if_l2_data(iface);
+#ifdef ROUTER_ONLY
 	otThreadSetLocalLeaderWeight(ot_context->instance, OT_LEADER_WEIGHT);
 #endif
-
+	initUDP_route(ot_context->instance);
+	sendUDP_route(ot_context->instance);
 #ifdef CONFIG_SYS_POWER_MANAGEMENT
 	sys_pm_ctrl_disable_state(SYS_POWER_STATE_SLEEP_1);
 	sys_pm_ctrl_disable_state(SYS_POWER_STATE_SLEEP_2);


### PR DESCRIPTION
To receive CoAP messages on Degu Gateway from Degu, we would need to bind a CoAP endpoint to a UDP port between Degu and Degu Gateway. This process ensures the passing of  ML-EID on Degu Gateway to every node on the Mesh.
There are some reasons to use ML-EID address specifically:
1. Upon Openthread Network, it is assigned to each node permanently and unique a ML-EID
2. Routing Thread Network with ML-EID enhances network performance (its own route table implementation)
3. No change the processing and implementing of Open Thread (OT Wiki)