### PR TITLE
Added routing feature

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,9 +29,9 @@ add_definitions(
   -DROUTER_ONLY
   )
 
-#add_library(libmicropython STATIC IMPORTED)
-#set_target_properties(libmicropython PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_SOURCE_DIR}/libmicropython.a)
-#target_link_libraries(app PUBLIC libmicropython)
+add_library(libmicropython STATIC IMPORTED)
+set_target_properties(libmicropython PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_SOURCE_DIR}/libmicropython.a)
+target_link_libraries(app PUBLIC libmicropython)
 
 zephyr_get_include_directories_for_lang_as_string(C includes)
 zephyr_get_system_include_directories_for_lang_as_string(C system_includes)

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ SRC_C = main.c \
 	degu_utils.c \
 	degu_ota.c \
 	degu_pm.c \
+	degu_routing.c \
 	zcoap.c \
 	help.c \
 	modusocket.c \

--- a/degu_routing.c
+++ b/degu_routing.c
@@ -1,0 +1,75 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Atmark Techno, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <misc/printk.h>
+#include <stdio.h>
+#include <string.h>
+#include "degu_routing.h"
+#include <openthread/udp.h>
+#include <openthread/message.h>
+#include <openthread/instance.h>
+#include "utils/code_utils.h"
+
+#define RECEV_MCAST_PORT 60888
+#define SEND_MCAST_PORT 50888
+static const char UDP_MCAST[] = "ff03::1";
+static const char UDP_MESG[] = "degu::mcast";
+static otUdpSocket sUdpSocket;
+
+void initUDP_route(otInstance *aInstance)
+{
+        otSockAddr  listenSockAddr;
+
+        memset(&sUdpSocket, 0, sizeof(sUdpSocket));
+        memset(&listenSockAddr, 0, sizeof(listenSockAddr));
+
+        listenSockAddr.mPort    = RECEV_MCAST_PORT;
+
+        otUdpOpen(aInstance, &sUdpSocket, UDPmessageHandler, aInstance);
+        otUdpBind(&sUdpSocket, &listenSockAddr);
+}
+
+void sendUDP_route(otInstance *aInstance)
+{
+       otError         error;
+       otMessage *     message = NULL;
+       otMessageInfo   messageInfo;
+       otIp6Address    destAddr;
+       memset(&messageInfo, 0, sizeof(messageInfo));
+
+       otIp6AddressFromString(UDP_MCAST, &destAddr);
+       messageInfo.mPeerAddr    = destAddr;
+       messageInfo.mPeerPort    = SEND_MCAST_PORT;
+        messageInfo.mInterfaceId = OT_NETIF_INTERFACE_ID_THREAD;
+
+       message = otUdpNewMessage(aInstance, NULL);
+       otEXPECT_ACTION(message != NULL, error = OT_ERROR_NO_BUFS);
+       error = otMessageAppend(message, UDP_MESG, sizeof(UDP_MESG));
+       otEXPECT(error == OT_ERROR_NONE);
+       error = otUdpSend(&sUdpSocket, message, &messageInfo);
+ exit:
+       if (error != OT_ERROR_NONE && message != NULL)
+       {
+               otMessageFree(message);
+       }
+}

--- a/degu_routing.h
+++ b/degu_routing.h
@@ -1,0 +1,37 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Atmark Techno, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef __DEGU_ROUTING_H__
+#define __DEGU_ROUTING_H__
+
+#include <stdio.h>
+#include <openthread/instance.h>
+#include <openthread/udp.h>
+
+void sendUDP_route(otInstance *aInstance);
+void UDPmessageHandler(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
+void initUDP_route(otInstance *aInstance);
+
+#endif /* ___DEGU_ROUTING_H__ */
+

--- a/degu_utils.c
+++ b/degu_utils.c
@@ -31,12 +31,51 @@
 #include <shell/shell.h>
 #include "zcoap.h"
 #include "degu_utils.h"
+#include "degu_routing.h"
+#include <string.h>
+#include <openthread/udp.h>
+#include <openthread/thread.h>
+#include <openthread/message.h>
+#include <openthread/ip6.h>
 
 #define I2C
 #include "libA71CH_api.h"
 
 extern char *net_byte_to_hex(char *ptr, u8_t byte, char base, bool pad);
 extern char *net_sprint_addr(sa_family_t af, const void *addr);
+char gw_addr[NET_IPV6_ADDR_LEN] = "ff03::1";
+
+static int Swap16(int before_swap)
+{
+	int after_swap;
+	after_swap = ( (((before_swap) >> 8) & 0x00FF) | (((before_swap) << 8) & 0xFF00) );
+	return after_swap;
+}
+
+void UDPmessageHandler(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
+{
+	char buf_ipv6[NET_IPV6_ADDR_LEN];
+	int equal_cmp, length;
+	char buf_mesg[256];
+	length = otMessageRead(aMessage, otMessageGetOffset(aMessage), buf_mesg, sizeof(buf_mesg) - 1);
+	buf_mesg[length] = '\0';
+	equal_cmp = strcmp(buf_mesg, "degu::mcast");
+	if (equal_cmp == 0) {
+	        sprintf(buf_ipv6, "%x:%x:%x:%x:%x:%x:%x:%x",
+                   Swap16(aMessageInfo->mPeerAddr.mFields.m16[0]),
+                   Swap16(aMessageInfo->mPeerAddr.mFields.m16[1]),
+                   Swap16(aMessageInfo->mPeerAddr.mFields.m16[2]),
+                   Swap16(aMessageInfo->mPeerAddr.mFields.m16[3]),
+                   Swap16(aMessageInfo->mPeerAddr.mFields.m16[4]),
+                   Swap16(aMessageInfo->mPeerAddr.mFields.m16[5]),
+                   Swap16(aMessageInfo->mPeerAddr.mFields.m16[6]),
+                   Swap16(aMessageInfo->mPeerAddr.mFields.m16[7]));
+		strcpy(gw_addr, buf_ipv6);
+	}
+	OT_UNUSED_VARIABLE(aContext);
+	OT_UNUSED_VARIABLE(aMessage);
+	OT_UNUSED_VARIABLE(aMessageInfo);
+}
 
 void get_eui64(char *eui64)
 {
@@ -53,7 +92,7 @@ void get_eui64(char *eui64)
 		(*buf)++;
 	}
 }
-
+#if 0
 static char *get_gw_addr(unsigned int prefix)
 {
 	struct net_if *iface;
@@ -86,6 +125,7 @@ static char *get_gw_addr(unsigned int prefix)
 
 	return NULL;
 }
+#endif
 
 int degu_send_asset(void);
 int degu_connect(void);
@@ -96,7 +136,6 @@ int degu_coap_request(u8_t *path, u8_t method, u8_t *payload, void (*callback)(u
 	struct sockaddr_in6 sockaddr;
 	u16_t payload_len;
 	bool last_block = false;
-	char gw_addr[NET_IPV6_ADDR_LEN];
 	char eui64[17];
 	char coap_path[40];
 	int ret;
@@ -111,7 +150,6 @@ int degu_coap_request(u8_t *path, u8_t method, u8_t *payload, void (*callback)(u
 
 	sockaddr.sin6_family = AF_INET6;
 
-	strcpy(gw_addr, get_gw_addr(64));
 	ret = zsock_inet_pton(AF_INET6, gw_addr, &sockaddr.sin6_addr);
 	if (ret <= 0) {
 		goto end;

--- a/degu_utils.c
+++ b/degu_utils.c
@@ -21,6 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+#include <misc/printk.h>
 #include <net/net_ip.h>
 #include <net/net_if.h>
 #include <net/socket.h>
@@ -71,6 +72,7 @@ void UDPmessageHandler(void *aContext, otMessage *aMessage, const otMessageInfo 
                    Swap16(aMessageInfo->mPeerAddr.mFields.m16[6]),
                    Swap16(aMessageInfo->mPeerAddr.mFields.m16[7]));
 		strcpy(gw_addr, buf_ipv6);
+		printk("Passed gateway address success: %s\n", gw_addr);
 	}
 	OT_UNUSED_VARIABLE(aContext);
 	OT_UNUSED_VARIABLE(aMessage);


### PR DESCRIPTION
To receive CoAP messages on Degu Gateway from Degu, we would need to bind a CoAP endpoint to a UDP port between Degu and Degu Gateway. This process ensures the passing of  ML-EID on Degu Gateway to every node on the Mesh.
There are some reasons to use ML-EID address specifically:
1. Upon Openthread Network, it is assigned to each node permanently and unique a ML-EID
2. Routing Thread Network with ML-EID enhances network performance (its own route table implementation)
3. No change the processing and implementing of Open Thread (OT Wiki)